### PR TITLE
Add mapper style sampling with username lookup

### DIFF
--- a/mapper_api.py
+++ b/mapper_api.py
@@ -1,67 +1,25 @@
 """
-mapper_api.py – helper for osu! API username lookup
+mapper_api.py – helper for osu! username lookup
 
 Provides functionality to look up osu! mapper usernames from their user IDs
-using the osu! API v2. Includes token caching and thread-safe token refresh.
+by scraping public profile pages. No API keys required.
 """
 from __future__ import annotations
-import os
-import time
-import threading
+import re
 from typing import Optional
 
 import requests
 
-_OSU_TOKEN: str | None = None
-_TOKEN_EXPIRES: float = 0.0
-_LOCK = threading.Lock()
-
-
-def _refresh_token() -> str:
-    """
-    Fetch a client-credentials token and cache it.
-    
-    Environment vars or app config:
-        OSU_CLIENT_ID     – e.g. 42371
-        OSU_CLIENT_SECRET – your secret
-    """
-    global _OSU_TOKEN, _TOKEN_EXPIRES
-    cid = os.getenv("OSU_CLIENT_ID")
-    sec = os.getenv("OSU_CLIENT_SECRET")
-    if not cid or not sec:
-        raise RuntimeError("osu! API credentials not set (OSU_CLIENT_ID, OSU_CLIENT_SECRET)")
-    
-    try:
-        r = requests.post(
-            "https://osu.ppy.sh/oauth/token",
-            json={
-                "client_id": int(cid),
-                "client_secret": sec,
-                "grant_type": "client_credentials",
-                "scope": "public",
-            },
-            timeout=15,
-        )
-        r.raise_for_status()
-        data = r.json()
-        _OSU_TOKEN = data["access_token"]
-        _TOKEN_EXPIRES = time.time() + data["expires_in"] - 60  # refresh 1 min early
-        return _OSU_TOKEN
-    except requests.RequestException as e:
-        raise RuntimeError(f"Failed to refresh osu! API token: {e}")
-
-
-def _get_token() -> str:
-    """Get a valid API token, refreshing if necessary."""
-    with _LOCK:
-        if _OSU_TOKEN is None or time.time() >= _TOKEN_EXPIRES:
-            return _refresh_token()
-        return _OSU_TOKEN
+# Simple in-memory cache for usernames
+_USERNAME_CACHE: dict[str, str] = {}
 
 
 def lookup_username(mapper_id: int | str) -> Optional[str]:
     """
     Return mapper's current username or None if not found.
+    
+    Scrapes the public osu! profile page to extract the username.
+    No API keys required.
     
     Args:
         mapper_id: The osu! user ID to look up
@@ -69,26 +27,46 @@ def lookup_username(mapper_id: int | str) -> Optional[str]:
     Returns:
         The username string or None if lookup fails
     """
-    try:
-        token = _get_token()
-    except Exception as e:
-        print(f"[mapper_api] Token error: {e}")
+    mapper_id = str(mapper_id).strip()
+    if not mapper_id:
         return None
     
-    url = f"https://osu.ppy.sh/api/v2/users/{mapper_id}/osu"
+    # Check cache first
+    if mapper_id in _USERNAME_CACHE:
+        return _USERNAME_CACHE[mapper_id]
+    
+    url = f"https://osu.ppy.sh/users/{mapper_id}"
     try:
         r = requests.get(
             url,
-            headers={"Authorization": f"Bearer {token}"},
+            headers={
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+            },
             timeout=10
         )
         if r.status_code == 404:
             print(f"[mapper_api] User {mapper_id} not found")
             return None
         if r.status_code != 200:
-            print(f"[mapper_api] Lookup failed: {r.status_code} - {r.text[:100]}")
+            print(f"[mapper_api] Lookup failed: {r.status_code}")
             return None
-        return r.json().get("username")
+        
+        # Extract username from page title: "username · player info | osu!"
+        match = re.search(r'<title>(.+?)\s*·\s*player', r.text)
+        if match:
+            username = match.group(1).strip()
+            _USERNAME_CACHE[mapper_id] = username
+            return username
+        
+        # Fallback: try to find in JSON data embedded in page
+        match = re.search(r'"username"\s*:\s*"([^"]+)"', r.text)
+        if match:
+            username = match.group(1)
+            _USERNAME_CACHE[mapper_id] = username
+            return username
+            
+        print(f"[mapper_api] Could not parse username from page")
+        return None
     except requests.RequestException as e:
         print(f"[mapper_api] Request error: {e}")
         return None
@@ -96,24 +74,16 @@ def lookup_username(mapper_id: int | str) -> Optional[str]:
 
 def lookup_user_info(mapper_id: int | str) -> Optional[dict]:
     """
-    Return full user info dict or None if not found.
-    Useful for getting additional info like avatar, country, etc.
+    Return basic user info dict or None if not found.
+    
+    Since we're scraping instead of using the API, this returns
+    limited information extracted from the profile page.
     """
-    try:
-        token = _get_token()
-    except Exception as e:
-        print(f"[mapper_api] Token error: {e}")
+    username = lookup_username(mapper_id)
+    if not username:
         return None
     
-    url = f"https://osu.ppy.sh/api/v2/users/{mapper_id}/osu"
-    try:
-        r = requests.get(
-            url,
-            headers={"Authorization": f"Bearer {token}"},
-            timeout=10
-        )
-        if r.status_code != 200:
-            return None
-        return r.json()
-    except requests.RequestException:
-        return None
+    return {
+        "id": int(mapper_id),
+        "username": username
+    }

--- a/mapper_api.py
+++ b/mapper_api.py
@@ -1,0 +1,119 @@
+"""
+mapper_api.py – helper for osu! API username lookup
+
+Provides functionality to look up osu! mapper usernames from their user IDs
+using the osu! API v2. Includes token caching and thread-safe token refresh.
+"""
+from __future__ import annotations
+import os
+import time
+import threading
+from typing import Optional
+
+import requests
+
+_OSU_TOKEN: str | None = None
+_TOKEN_EXPIRES: float = 0.0
+_LOCK = threading.Lock()
+
+
+def _refresh_token() -> str:
+    """
+    Fetch a client-credentials token and cache it.
+    
+    Environment vars or app config:
+        OSU_CLIENT_ID     – e.g. 42371
+        OSU_CLIENT_SECRET – your secret
+    """
+    global _OSU_TOKEN, _TOKEN_EXPIRES
+    cid = os.getenv("OSU_CLIENT_ID")
+    sec = os.getenv("OSU_CLIENT_SECRET")
+    if not cid or not sec:
+        raise RuntimeError("osu! API credentials not set (OSU_CLIENT_ID, OSU_CLIENT_SECRET)")
+    
+    try:
+        r = requests.post(
+            "https://osu.ppy.sh/oauth/token",
+            json={
+                "client_id": int(cid),
+                "client_secret": sec,
+                "grant_type": "client_credentials",
+                "scope": "public",
+            },
+            timeout=15,
+        )
+        r.raise_for_status()
+        data = r.json()
+        _OSU_TOKEN = data["access_token"]
+        _TOKEN_EXPIRES = time.time() + data["expires_in"] - 60  # refresh 1 min early
+        return _OSU_TOKEN
+    except requests.RequestException as e:
+        raise RuntimeError(f"Failed to refresh osu! API token: {e}")
+
+
+def _get_token() -> str:
+    """Get a valid API token, refreshing if necessary."""
+    with _LOCK:
+        if _OSU_TOKEN is None or time.time() >= _TOKEN_EXPIRES:
+            return _refresh_token()
+        return _OSU_TOKEN
+
+
+def lookup_username(mapper_id: int | str) -> Optional[str]:
+    """
+    Return mapper's current username or None if not found.
+    
+    Args:
+        mapper_id: The osu! user ID to look up
+        
+    Returns:
+        The username string or None if lookup fails
+    """
+    try:
+        token = _get_token()
+    except Exception as e:
+        print(f"[mapper_api] Token error: {e}")
+        return None
+    
+    url = f"https://osu.ppy.sh/api/v2/users/{mapper_id}/osu"
+    try:
+        r = requests.get(
+            url,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10
+        )
+        if r.status_code == 404:
+            print(f"[mapper_api] User {mapper_id} not found")
+            return None
+        if r.status_code != 200:
+            print(f"[mapper_api] Lookup failed: {r.status_code} - {r.text[:100]}")
+            return None
+        return r.json().get("username")
+    except requests.RequestException as e:
+        print(f"[mapper_api] Request error: {e}")
+        return None
+
+
+def lookup_user_info(mapper_id: int | str) -> Optional[dict]:
+    """
+    Return full user info dict or None if not found.
+    Useful for getting additional info like avatar, country, etc.
+    """
+    try:
+        token = _get_token()
+    except Exception as e:
+        print(f"[mapper_api] Token error: {e}")
+        return None
+    
+    url = f"https://osu.ppy.sh/api/v2/users/{mapper_id}/osu"
+    try:
+        r = requests.get(
+            url,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10
+        )
+        if r.status_code != 200:
+            return None
+        return r.json()
+    except requests.RequestException:
+        return None

--- a/mapper_scrape.py
+++ b/mapper_scrape.py
@@ -1,5 +1,5 @@
 """
-mapper_api.py – helper for osu! username lookup
+mapper_scrape.py – osu! username lookup via web scraping
 
 Provides functionality to look up osu! mapper usernames from their user IDs
 by scraping public profile pages. No API keys required.

--- a/static/app.js
+++ b/static/app.js
@@ -969,6 +969,43 @@ $(document).ready(function() {
         $("#model").on('change', () => UIManager.updateModelSettings());
         $("#gamemode").on('change', () => UIManager.updateConditionalFields());
 
+        // Mapper ID lookup button
+        $("#lookup-mapper-btn").on('click', function() {
+            const mapperId = $("#mapper_id").val().trim();
+            if (!mapperId) {
+                Utils.showFlashMessage("Please enter a mapper ID first", "error");
+                return;
+            }
+            
+            const $btn = $(this);
+            const $display = $("#mapper-name-display");
+            $btn.prop('disabled', true).text('Looking up...');
+            $display.text('');
+            
+            $.ajax({
+                url: '/lookup_mapper_name',
+                method: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({ mapper_id: mapperId }),
+                success: function(data) {
+                    if (data.username) {
+                        $display.text('✓ ' + data.username).css('color', '#4CAF50');
+                        Utils.showFlashMessage(`Found mapper: ${data.username}`, "success");
+                    } else {
+                        $display.text('User not found').css('color', '#f44336');
+                    }
+                },
+                error: function(xhr) {
+                    const msg = xhr.responseJSON?.error || "Lookup failed";
+                    $display.text(msg).css('color', '#f44336');
+                    Utils.showFlashMessage(msg, "error");
+                },
+                complete: function() {
+                    $btn.prop('disabled', false).text('Lookup');
+                }
+            });
+        });
+
         // Initial UI updates
         UIManager.updateModelSettings();
     }

--- a/static/style.css
+++ b/static/style.css
@@ -737,3 +737,21 @@ input[type="number"]:hover::-webkit-outer-spin-button {
 .clear-input-btn:active {
     transform: translateY(-50%) scale(0.95);
 }
+
+
+/* Helper text for mapper lookup */
+.helper-text {
+    font-size: 0.85em;
+    margin-top: 4px;
+    display: block;
+}
+
+.input-with-button {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.input-with-button input {
+    flex: 1;
+}

--- a/template/index.html
+++ b/template/index.html
@@ -119,8 +119,14 @@
                     <button type="button" class="browse-button" data-browse-type="folder" data-target="lora_path">Browse...</button>
                 </div>
 
-                <label for="mapper_id" title="Mapper user ID for style">Mapper ID:</label>
-                <input type="text" id="mapper_id" name="mapper_id" />
+                <div class="form-group">
+                    <label for="mapper_id" title="Mapper user ID for style sampling. Enter an osu! user ID to generate maps in their style.">Mapper ID:</label>
+                    <div class="input-with-button">
+                        <input type="text" id="mapper_id" name="mapper_id" placeholder="e.g. 124493" />
+                        <button type="button" id="lookup-mapper-btn" class="browse-button" title="Look up mapper name from ID">Lookup</button>
+                    </div>
+                    <span id="mapper-name-display" class="helper-text"></span>
+                </div>
 
                 <div class="form-group conditional-field" id="group-year" data-hide-for-model="v30">
                     <label for="year" title="Year of the song (2007-2023)">Year (2007-2023):</label>

--- a/web-ui.py
+++ b/web-ui.py
@@ -17,13 +17,12 @@ from flask import Flask, render_template, request, Response, jsonify
 from config import InferenceConfig
 from inference import autofill_paths
 
-# osu! API for mapper username lookup (optional feature)
-# Get your credentials at: https://osu.ppy.sh/home/account/edit#oauth
+# osu! mapper username lookup via web scraping (no API keys required)
 try:
-    from mapper_api import lookup_username
-    MAPPER_API_AVAILABLE = True
+    from mapper_scrape import lookup_username
+    MAPPER_SCRAPE_AVAILABLE = True
 except ImportError:
-    MAPPER_API_AVAILABLE = False
+    MAPPER_SCRAPE_AVAILABLE = False
     def lookup_username(mapper_id):
         return None
 
@@ -181,9 +180,9 @@ def lookup_mapper_name_route():
     
     Scrapes the public osu! profile page - no API keys required.
     """
-    if not MAPPER_API_AVAILABLE:
+    if not MAPPER_SCRAPE_AVAILABLE:
         return jsonify({
-            "error": "Mapper API not available. Ensure mapper_api.py exists and requests is installed."
+            "error": "Mapper scrape not available. Ensure mapper_scrape.py exists and requests is installed."
         }), 501
 
     data = request.get_json()

--- a/web-ui.py
+++ b/web-ui.py
@@ -179,38 +179,27 @@ def index():
 def lookup_mapper_name_route():
     """Look up a mapper's username from their osu! user ID.
     
-    Requires OSU_CLIENT_ID and OSU_CLIENT_SECRET environment variables.
-    Get your credentials at: https://osu.ppy.sh/home/account/edit#oauth
+    Scrapes the public osu! profile page - no API keys required.
     """
     if not MAPPER_API_AVAILABLE:
         return jsonify({
             "error": "Mapper API not available. Ensure mapper_api.py exists and requests is installed."
         }), 501
-    
+
     data = request.get_json()
     mapper_id = data.get('mapper_id', '')
-    
+
     if not mapper_id:
         return jsonify({"error": "mapper_id is required"}), 400
-    
+
     try:
         username = lookup_username(mapper_id)
         if username:
             return jsonify({"username": username})
         else:
-            return jsonify({"error": "User not found or API error"}), 404
+            return jsonify({"error": "User not found"}), 404
     except Exception as e:
-        error_msg = str(e)
-        # Check for missing credentials
-        if "credentials not set" in error_msg.lower():
-            return jsonify({
-                "error": "osu! API credentials not configured. Set OSU_CLIENT_ID and OSU_CLIENT_SECRET environment variables."
-            }), 503
-        return jsonify({"error": error_msg}), 500
-
-
-@app.route('/start_inference', methods=['POST'])
-def start_inference():
+        return jsonify({"error": str(e)}), 500
     """Starts the inference process based on form data."""
     global current_process
     with process_lock:


### PR DESCRIPTION
Adds mapper ID input with username lookup functionality for style-based beatmap generation.

## Changes
- Add `mapper_scrape.py` module for looking up osu! usernames by ID
- Add `/lookup_mapper_name` endpoint for username lookup
- Add "Lookup" button next to mapper ID field in the UI
- Display resolved username when found

## How it works
- Scrapes the public osu! profile page (`osu.ppy.sh/users/{id}`)
- No API keys or credentials required
- Caches lookups to avoid repeated requests

This allows users to input a mapper ID and see the resolved username, useful for generating beatmaps in a specific mapper's style.