### PR TITLE
Fix compatibility with newer transformers/PEFT versions

### DIFF
--- a/osuT5/osuT5/model/modeling_mapperatorinator.py
+++ b/osuT5/osuT5/model/modeling_mapperatorinator.py
@@ -68,8 +68,12 @@ class Mapperatorinator(PreTrainedModel, GenerationMixin):
     _supports_cache_class = True
     _supports_static_cache = True
 
-    def __init__(self, config: MapperatorinatorConfig):
-        super().__init__(config)
+    def __init__(self, config: MapperatorinatorConfig, **kwargs):
+        super().__init__(config, **kwargs)
+
+        # get_backbone_model reads dtype from config, but from_pretrained passes it as a kwarg
+        if not hasattr(config, 'dtype'):
+            config.dtype = kwargs.get('dtype', None)
 
         if not config.input_raw_wave:
             self.spectrogram = MelSpectrogram(


### PR DESCRIPTION
Fixes compatibility issues when using newer versions of transformers and PEFT libraries.

## Changes
- **`Mapperatorinator.__init__`**: Accept `**kwargs` to handle additional keyword arguments passed by newer transformers versions
- **`MapperatorinatorConfig`**: Store `dtype` kwarg on config object so `get_backbone_model` can access it

## Context
When using transformers >= 4.57 with PEFT >= 0.18, the model initialization fails because newer transformers passes additional kwargs (`dtype`, etc.) that the custom `__init__` doesn't accept. These changes make the model forward-compatible.