### PR TITLE
Add LoRA fine-tuning pipeline for custom year ranges

### DIFF
--- a/configs/train/lora_2024_2025.yaml
+++ b/configs/train/lora_2024_2025.yaml
@@ -1,0 +1,59 @@
+# LoRA fine-tune config for V31 on 2024-2025 beatmap data.
+# Inherits from lora.yaml but targets V31 with a year-filtered dataset.
+#
+# Usage:
+#   python osuT5/train.py -cn lora_2024_2025
+#   python osuT5/train.py -cn lora_2024_2025 \
+#     data.train_dataset_path="/path/to/dataset" \
+#     data.test_dataset_path="/path/to/dataset"
+
+defaults:
+  - v31
+  - _self_
+
+compile: false
+precision: 'bf16'
+enable_lora: true
+
+pretrained_path: "OliBomby/Mapperatorinator-v31"
+
+data:
+  dataset_type: "mmrs"
+  train_dataset_path: "/workspace/datasets/MMRS_2024_2025"
+  test_dataset_path: "/workspace/datasets/MMRS_2024_2025"
+  train_dataset_start: 0
+  train_dataset_end: 13491
+  test_dataset_start: 13491
+  test_dataset_end: 14991
+
+  min_year: 2024
+  max_year: 2025
+  add_year_token: true
+
+optim:
+  name: muon
+  base_lr: 0.0004
+  base_lr_2: 0.0001
+  batch_size: 32
+  grad_acc: 32             # per-GPU batch of 1, fits 12GB VRAM
+  total_steps: 2000
+  warmup_steps: 100
+  sustain_steps: 0
+  weight_decay: 0.01
+  lr_scheduler: cosine
+  final_cosine: 0
+
+lora:
+  r: 64
+  lora_alpha: 128
+  target_modules: ['k_proj', 'v_proj', 'q_proj', 'out_proj']
+  lora_dropout: 0.05
+  bias: "none"
+  init_lora_weights: "pissa"
+
+eval:
+  every_steps: 200
+  steps: 100
+
+checkpoint:
+  every_steps: 200

--- a/training/README.md
+++ b/training/README.md
@@ -1,0 +1,92 @@
+# Training Pipeline: 2024-2025 Year Support
+
+Fine-tune Mapperatorinator on recent (2024-2025) beatmap data using LoRA.
+
+## Prerequisites
+
+- **osu! OAuth credentials** — get them at https://osu.ppy.sh/home/account/edit → OAuth → New Application
+- **NVIDIA GPU with CUDA** (8GB+ VRAM recommended; 24GB for full batch sizes)
+- **Python 3.10/3.11** with the project's venv activated
+- **~50-100GB disk space** for .osz files + dataset
+
+## Quick Start (Windows)
+
+```powershell
+# Set osu! API credentials
+$env:OSU_CLIENT_ID = "your_client_id"
+$env:OSU_CLIENT_SECRET = "your_client_secret"
+
+# Run the full pipeline (download → build dataset → train)
+.\training\run_pipeline.ps1 -Step all
+```
+
+## Quick Start (Linux/macOS)
+
+```bash
+export OSU_CLIENT_ID="your_client_id"
+export OSU_CLIENT_SECRET="your_client_secret"
+
+bash training/run_pipeline.sh all
+```
+
+## Individual Steps
+
+### 1. Download Beatmaps
+
+Downloads ranked and loved beatmaps from 2024-2025 as `.osz` files using the osu! API v2.
+
+```powershell
+.\training\run_pipeline.ps1 -Step download
+# or manually:
+python training/download_beatmaps.py --client-id YOUR_ID --client-secret YOUR_SECRET --output training/osz_2024_2025
+```
+
+### 2. Build Dataset
+
+Converts `.osz` files into MMRS format (the training format Mapperatorinator expects).
+
+```powershell
+.\training\run_pipeline.ps1 -Step dataset
+# or manually:
+python training/build_dataset.py --input training/osz_2024_2025 --output training/dataset_2024_2025
+```
+
+### 3. Train (LoRA Fine-Tune)
+
+Fine-tunes the V31 model using LoRA on the new dataset.
+
+```powershell
+.\training\run_pipeline.ps1 -Step train
+# or manually:
+python osuT5/train.py -cn lora_2024_2025 data.train_dataset_path="path/to/dataset" data.test_dataset_path="path/to/dataset"
+```
+
+## Using the Trained Model
+
+After training completes, the LoRA checkpoint will be saved in the `logs/` directory.
+
+**Web UI:** Set the "LoRA Path or ID" field to the checkpoint directory path.
+
+**CLI:**
+```bash
+python inference.py lora_path="logs/<run>/checkpoints/<step>" year=2025
+```
+
+## Config
+
+The training config is at `configs/train/lora_2024_2025.yaml`. Key settings:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `total_steps` | 2000 | Training iterations |
+| `lora_r` | 64 | LoRA rank (higher = more capacity) |
+| `lora_alpha` | 128 | LoRA scaling factor |
+| `learning_rate` | 0.0004 | Muon optimizer LR |
+| `min_year` / `max_year` | 2024 / 2025 | Year range filter |
+
+## Notes
+
+- LoRA fine-tuning is much lighter than full retraining (~2000 steps vs 65000+)
+- The base model (V31) already knows mapping patterns; LoRA adapts it to 2024-2025 data
+- Training takes roughly 1-4 hours depending on GPU and dataset size
+- Downloads use the catboy.best mirror for .osz files (faster than osu! direct)

--- a/training/build_dataset.py
+++ b/training/build_dataset.py
@@ -1,0 +1,298 @@
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+from tqdm import tqdm
+
+
+def parse_osu_metadata(osu_path: Path) -> dict:
+    """Parse metadata from a .osu file header."""
+    metadata = {}
+    section = None
+
+    try:
+        with open(osu_path, "r", encoding="utf-8-sig") as f:
+            for line in f:
+                line = line.strip()
+
+                if line.startswith("[") and line.endswith("]"):
+                    section = line[1:-1]
+                    continue
+
+                if section in ("General", "Metadata", "Difficulty") and ":" in line:
+                    key, _, value = line.partition(":")
+                    metadata[key.strip()] = value.strip()
+
+                # Stop after we have what we need
+                if section == "HitObjects":
+                    break
+    except (UnicodeDecodeError, OSError):
+        pass
+
+    return metadata
+
+
+def extract_osz(osz_path: Path, output_dir: Path) -> list[dict]:
+    """Extract an .osz file and return metadata for each difficulty."""
+    beatmapset_id = osz_path.stem
+    set_dir = output_dir / "data" / str(beatmapset_id)
+
+    if set_dir.exists():
+        # Already extracted
+        return []
+
+    set_dir.mkdir(parents=True, exist_ok=True)
+    results = []
+
+    try:
+        with zipfile.ZipFile(osz_path, "r") as z:
+            # Only extract .osu files and audio — skip images, videos, storyboards
+            osu_files = [n for n in z.namelist() if n.endswith(".osu")]
+            audio_files = [n for n in z.namelist()
+                           if n.lower().endswith((".mp3", ".ogg", ".wav"))]
+
+            # Extract audio (just the first one found)
+            if audio_files:
+                z.extract(audio_files[0], set_dir)
+
+            # Extract .osu files
+            for name in osu_files:
+                z.extract(name, set_dir)
+
+            # Parse each .osu file
+            for name in osu_files:
+                    osu_path = set_dir / name
+                    meta = parse_osu_metadata(osu_path)
+
+                    beatmap_id = meta.get("BeatmapID", "0")
+                    mode = int(meta.get("Mode", "0"))
+                    difficulty_name = meta.get("Version", "Unknown")
+
+                    audio_filename = meta.get("AudioFilename", "")
+
+                    results.append({
+                        "BeatmapSetId": int(beatmapset_id),
+                        "Id": int(beatmap_id),
+                        "BeatmapSetFolder": str(beatmapset_id),
+                        "BeatmapFile": name,
+                        "AudioFile": audio_filename,
+                        "ModeInt": mode,
+                        "DifficultyName": difficulty_name,
+                    })
+
+    except (zipfile.BadZipFile, OSError) as e:
+        print(f"  Failed to extract {osz_path}: {e}")
+        if set_dir.exists():
+            shutil.rmtree(set_dir, ignore_errors=True)
+        return []
+
+    return results
+
+
+def enrich_with_api_metadata(records: list[dict], api_metadata_path: Path) -> list[dict]:
+    """Merge extracted .osu metadata with API metadata (ranked date, star rating)."""
+    if not api_metadata_path.exists():
+        print("Warning: No API metadata file found. Star ratings and ranked dates will be estimated.")
+        return records
+
+    with open(api_metadata_path, "r", encoding="utf-8") as f:
+        api_data = json.load(f)
+
+    # Build lookup: beatmapset_id -> {beatmap_id -> beatmap_data}
+    api_lookup = {}
+    for bset in api_data:
+        bset_id = bset["id"]
+        api_lookup[bset_id] = {
+            "ranked_date": bset.get("ranked_date") or bset.get("submitted_date"),
+            "submitted_date": bset.get("submitted_date"),
+            "user_id": bset.get("user_id", 0),
+            "beatmaps": {}
+        }
+        for bm in bset.get("beatmaps", []):
+            api_lookup[bset_id]["beatmaps"][bm["id"]] = {
+                "difficulty_rating": bm.get("difficulty_rating", 0),
+                "mode_int": bm.get("mode_int", 0),
+            }
+
+    enriched = []
+    for rec in records:
+        bset_id = rec["BeatmapSetId"]
+        bm_id = rec["Id"]
+
+        api_bset = api_lookup.get(bset_id, {})
+        api_bm = api_bset.get("beatmaps", {}).get(bm_id, {})
+
+        # Parse ranked date (as naive datetime to match MMRS format)
+        ranked_str = api_bset.get("ranked_date")
+        if ranked_str:
+            try:
+                ranked_date = datetime.fromisoformat(ranked_str.replace("Z", "+00:00")).replace(tzinfo=None)
+            except (ValueError, AttributeError):
+                ranked_date = datetime(2024, 1, 1)
+        else:
+            ranked_date = datetime(2024, 1, 1)
+
+        # Parse submitted date (as naive datetime to match MMRS format)
+        submitted_str = api_bset.get("submitted_date")
+        if submitted_str:
+            try:
+                submitted_date = datetime.fromisoformat(submitted_str.replace("Z", "+00:00")).replace(tzinfo=None)
+            except (ValueError, AttributeError):
+                submitted_date = ranked_date
+        else:
+            submitted_date = ranked_date
+
+        # StarRating must be a 7-element array for speeds [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0]
+        # We only have the 1.0x speed rating; estimate others with rough scaling
+        base_sr = api_bm.get("difficulty_rating", 0.0)
+        rec["StarRating"] = [
+            base_sr * 0.6,   # 0.5x
+            base_sr * 0.8,   # 0.75x
+            base_sr,         # 1.0x (actual value)
+            base_sr * 1.15,  # 1.25x
+            base_sr * 1.3,   # 1.5x
+            base_sr * 1.45,  # 1.75x
+            base_sr * 1.6,   # 2.0x
+        ]
+        rec["DifficultyRating"] = base_sr
+        rec["RankedDate"] = ranked_date
+        rec["SubmittedDate"] = submitted_date
+        rec["UserId"] = api_bset.get("user_id", 0)
+        rec["ModeInt"] = api_bm.get("mode_int", rec.get("ModeInt", 0))
+        enriched.append(rec)
+
+    return enriched
+
+
+def build_metadata_parquet(records: list[dict], output_dir: Path):
+    """Build the metadata.parquet file in MMRS format."""
+    if not records:
+        print("No records to write!")
+        return
+
+    df = pd.DataFrame(records)
+
+    # Add BeatmapIdx (sequential index)
+    df["BeatmapIdx"] = range(len(df))
+
+    # Ensure correct types
+    df["BeatmapSetId"] = df["BeatmapSetId"].astype(int)
+    df["Id"] = df["Id"].astype(int)
+    df["ModeInt"] = df["ModeInt"].astype(int)
+    df["DifficultyRating"] = df["DifficultyRating"].astype(float)
+    df["UserId"] = df["UserId"].astype(int)
+
+    # Sort by BeatmapSetId
+    df = df.sort_values("BeatmapSetId")
+
+    # Do NOT set_index here — data_utils.load_mmrs_metadata() does that itself
+    parquet_path = output_dir / "metadata.parquet"
+    df.to_parquet(parquet_path, index=False)
+
+    # Print stats
+    n_sets = df["BeatmapSetId"].nunique()
+    n_maps = len(df)
+    print(f"\nDataset built:")
+    print(f"  Beatmap sets: {n_sets}")
+    print(f"  Total difficulties: {n_maps}")
+    print(f"  Output: {parquet_path}")
+
+    # Year distribution
+    if "RankedDate" in df.columns:
+        year_counts = df["RankedDate"].dt.year.value_counts().sort_index()
+        print(f"\n  Year distribution:")
+        for year, count in year_counts.items():
+            print(f"    {year}: {count} beatmaps")
+
+    # Gamemode distribution
+    mode_names = {0: "Standard", 1: "Taiko", 2: "Catch", 3: "Mania"}
+    mode_counts = df["ModeInt"].value_counts().sort_index()
+    print(f"\n  Gamemode distribution:")
+    for mode, count in mode_counts.items():
+        print(f"    {mode_names.get(mode, f'Mode {mode}')}: {count}")
+
+    return n_sets
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build MMRS dataset from .osz files")
+    parser.add_argument("--input", required=True,
+                        help="Directory containing .osz files (from download_beatmaps.py)")
+    parser.add_argument("--output", required=True,
+                        help="Output directory for MMRS dataset")
+    parser.add_argument("--delete-osz", action="store_true",
+                        help="Delete each .osz file after successful extraction to save disk space")
+    args = parser.parse_args()
+
+    input_dir = Path(args.input)
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    osz_files = sorted(input_dir.glob("*.osz"))
+    data_dir = output_dir / "data"
+    if not osz_files and not data_dir.exists():
+        print(f"No .osz files found in {input_dir}")
+        sys.exit(1)
+
+    if osz_files:
+        print(f"Found {len(osz_files)} .osz files")
+    else:
+        print(f"No .osz files found, scanning already-extracted data in {data_dir}")
+
+    # Extract all .osz files
+    all_records = []
+    for osz_path in tqdm(osz_files, desc="Extracting .osz files"):
+        records = extract_osz(osz_path, output_dir)
+        all_records.extend(records)
+        # Delete .osz after successful extraction to free disk space
+        if args.delete_osz and records:
+            osz_path.unlink()
+
+    # Also check already-extracted directories for records
+    if not all_records:
+        print("Checking already-extracted directories...")
+        data_dir = output_dir / "data"
+        if data_dir.exists():
+            for set_dir in sorted(data_dir.iterdir()):
+                if set_dir.is_dir():
+                    for osu_file in set_dir.glob("*.osu"):
+                        meta = parse_osu_metadata(osu_file)
+                        all_records.append({
+                            "BeatmapSetId": int(set_dir.name),
+                            "Id": int(meta.get("BeatmapID", "0")),
+                            "BeatmapSetFolder": set_dir.name,
+                            "BeatmapFile": osu_file.name,
+                            "AudioFile": meta.get("AudioFilename", ""),
+                            "ModeInt": int(meta.get("Mode", "0")),
+                            "DifficultyName": meta.get("Version", "Unknown"),
+                        })
+
+    print(f"\nTotal beatmap difficulties found: {len(all_records)}")
+
+    # Enrich with API metadata
+    api_metadata_path = input_dir / "beatmapset_metadata.json"
+    all_records = enrich_with_api_metadata(all_records, api_metadata_path)
+
+    # Build parquet
+    n_sets = build_metadata_parquet(all_records, output_dir)
+
+    if n_sets:
+        train_end = int(n_sets * 0.9)
+        print(f"\n--- Training Config Values ---")
+        print(f"  train_dataset_path: \"{output_dir.resolve()}\"")
+        print(f"  train_dataset_start: 0")
+        print(f"  train_dataset_end: {train_end}")
+        print(f"  test_dataset_start: {train_end}")
+        print(f"  test_dataset_end: {n_sets}")
+        print(f"\nUpdate configs/train/lora_2024_2025.yaml with these values.")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/download_beatmaps.py
+++ b/training/download_beatmaps.py
@@ -1,0 +1,232 @@
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+from tqdm import tqdm
+
+DEFAULT_MAPPERS_PATH = "datasets/beatmap_users.json"
+
+API_BASE = "https://osu.ppy.sh/api/v2"
+TOKEN_URL = "https://osu.ppy.sh/oauth/token"
+# catboy.best is a commonly used osu! beatmap mirror
+MIRROR_URL = "https://catboy.best/d/{beatmapset_id}"
+
+
+def get_oauth_token(client_id: str, client_secret: str) -> str:
+    """Get an OAuth2 client credentials token from osu! API."""
+    resp = requests.post(TOKEN_URL, json={
+        "client_id": int(client_id),
+        "client_secret": client_secret,
+        "grant_type": "client_credentials",
+        "scope": "public",
+    })
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+
+def search_beatmapsets(token: str, year_start: int, year_end: int, status: str = "ranked") -> list[dict]:
+    """Search for all beatmap sets ranked/loved in the given year range."""
+    headers = {"Authorization": f"Bearer {token}"}
+    all_sets = []
+    cursor_string = None
+
+    # osu! API search uses created/ranked date filters
+    # We search year by year for better pagination
+    for year in range(year_start, year_end + 1):
+        print(f"\nSearching for {status} beatmaps from {year}...")
+        cursor_string = None
+        year_count = 0
+
+        while True:
+            params = {
+                "s": status,
+                "sort": "ranked_asc",
+                # Filter by ranked date range
+                "q": f"ranked>={year}-01-01 ranked<{year + 1}-01-01",
+            }
+            if cursor_string:
+                params["cursor_string"] = cursor_string
+
+            resp = requests.get(
+                f"{API_BASE}/beatmapsets/search",
+                headers=headers,
+                params=params,
+            )
+
+            if resp.status_code == 429:
+                retry_after = int(resp.headers.get("Retry-After", 5))
+                print(f"Rate limited, waiting {retry_after}s...")
+                time.sleep(retry_after)
+                continue
+
+            resp.raise_for_status()
+            data = resp.json()
+
+            beatmapsets = data.get("beatmapsets", [])
+            if not beatmapsets:
+                break
+
+            all_sets.extend(beatmapsets)
+            year_count += len(beatmapsets)
+
+            cursor_string = data.get("cursor_string")
+            if not cursor_string:
+                break
+
+            # Respect rate limits
+            time.sleep(0.5)
+
+        print(f"  Found {year_count} {status} beatmap sets from {year}")
+
+    return all_sets
+
+
+def load_mapper_user_ids(mappers_path: str) -> set[int]:
+    """Load unique mapper user IDs from beatmap_users.json."""
+    path = Path(mappers_path)
+    if not path.exists():
+        print(f"Error: Mappers file not found: {path}")
+        sys.exit(1)
+
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    user_ids = {entry["user_id"] for entry in data}
+    print(f"Loaded {len(user_ids)} unique mapper IDs from {path}")
+    return user_ids
+
+
+def filter_by_mappers(beatmapsets: list[dict], mapper_ids: set[int]) -> list[dict]:
+    """Filter beatmap sets to only those created by known mappers."""
+    filtered = [s for s in beatmapsets if s.get("user_id") in mapper_ids]
+    print(f"  Mapper filter: {len(filtered)}/{len(beatmapsets)} sets match known mappers")
+    return filtered
+
+
+def download_osz(beatmapset_id: int, output_dir: Path, existing_ids: set) -> bool:
+    """Download a single .osz file from the mirror."""
+    if beatmapset_id in existing_ids:
+        return False
+
+    osz_path = output_dir / f"{beatmapset_id}.osz"
+    if osz_path.exists():
+        return False
+
+    url = MIRROR_URL.format(beatmapset_id=beatmapset_id)
+    try:
+        resp = requests.get(url, stream=True, timeout=60)
+        if resp.status_code == 404:
+            return False
+        resp.raise_for_status()
+
+        with open(osz_path, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=8192):
+                f.write(chunk)
+        return True
+
+    except Exception as e:
+        # Clean up partial downloads
+        if osz_path.exists():
+            osz_path.unlink()
+        print(f"  Failed to download {beatmapset_id}: {e}")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download osu! beatmaps for training")
+    parser.add_argument("--client-id", default=os.environ.get("OSU_CLIENT_ID"),
+                        help="osu! OAuth client ID (or set OSU_CLIENT_ID env var)")
+    parser.add_argument("--client-secret", default=os.environ.get("OSU_CLIENT_SECRET"),
+                        help="osu! OAuth client secret (or set OSU_CLIENT_SECRET env var)")
+    parser.add_argument("--output", default="./training/osz_2024_2025",
+                        help="Output directory for .osz files")
+    parser.add_argument("--year-start", type=int, default=2024,
+                        help="Start year (inclusive)")
+    parser.add_argument("--year-end", type=int, default=2025,
+                        help="End year (inclusive)")
+    parser.add_argument("--status", nargs="+", default=["ranked", "loved"],
+                        help="Beatmap statuses to download (ranked, loved, qualified)")
+    parser.add_argument("--metadata-only", action="store_true",
+                        help="Only fetch metadata, don't download .osz files")
+    parser.add_argument("--mappers-path", default=DEFAULT_MAPPERS_PATH,
+                        help="Path to beatmap_users.json for mapper filtering (default: datasets/beatmap_users.json)")
+    parser.add_argument("--filter-mappers", action="store_true",
+                        help="Only download maps from mappers in beatmap_users.json")
+    args = parser.parse_args()
+
+    if not args.client_id or not args.client_secret:
+        print("Error: osu! OAuth credentials required.")
+        print("Either pass --client-id and --client-secret, or set OSU_CLIENT_ID and OSU_CLIENT_SECRET env vars.")
+        print("Get credentials at: https://osu.ppy.sh/home/account/edit (OAuth section)")
+        sys.exit(1)
+
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Get OAuth token
+    print("Authenticating with osu! API...")
+    token = get_oauth_token(args.client_id, args.client_secret)
+    print("Authenticated successfully.")
+
+    # Search for beatmap sets
+    all_sets = []
+    for status in args.status:
+        sets = search_beatmapsets(token, args.year_start, args.year_end, status)
+        all_sets.extend(sets)
+
+    # Deduplicate by ID
+    seen = set()
+    unique_sets = []
+    for s in all_sets:
+        if s["id"] not in seen:
+            seen.add(s["id"])
+            unique_sets.append(s)
+    all_sets = unique_sets
+
+    print(f"\nTotal unique beatmap sets found: {len(all_sets)}")
+
+    # Optionally filter to known mappers only
+    if args.filter_mappers:
+        mapper_ids = load_mapper_user_ids(args.mappers_path)
+        all_sets = filter_by_mappers(all_sets, mapper_ids)
+        print(f"After mapper filter: {len(all_sets)} sets")
+
+    # Save metadata
+    metadata_path = output_dir / "beatmapset_metadata.json"
+    with open(metadata_path, "w", encoding="utf-8") as f:
+        json.dump(all_sets, f, default=str)
+    print(f"Saved metadata to {metadata_path}")
+
+    if args.metadata_only:
+        print("Metadata-only mode, skipping downloads.")
+        return
+
+    # Download .osz files
+    existing_ids = {int(p.stem) for p in output_dir.glob("*.osz")}
+    to_download = [s for s in all_sets if s["id"] not in existing_ids]
+    print(f"Already downloaded: {len(existing_ids)}")
+    print(f"To download: {len(to_download)}")
+
+    downloaded = 0
+    failed = 0
+    for beatmapset in tqdm(to_download, desc="Downloading"):
+        if download_osz(beatmapset["id"], output_dir, set()):
+            downloaded += 1
+        else:
+            failed += 1
+        # Rate limit downloads
+        time.sleep(0.3)
+
+    print(f"\nDownload complete: {downloaded} new, {failed} failed, {len(existing_ids)} already had")
+    print(f"Total .osz files: {len(list(output_dir.glob('*.osz')))}")
+    print(f"\nNext step: Create dataset with Mapperator:")
+    print(f"  Mapperator.ConsoleApp.exe dataset2 -i \"{output_dir}\" -o \"./training/dataset_2024_2025\"")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/run_pipeline.ps1
+++ b/training/run_pipeline.ps1
@@ -1,0 +1,146 @@
+# =============================================================================
+# Full Training Pipeline for Mapperatorinator 2024-2025 Year Support (Windows)
+# =============================================================================
+#
+# Prerequisites:
+#   - osu! OAuth credentials (https://osu.ppy.sh/home/account/edit -> OAuth)
+#   - NVIDIA GPU with CUDA
+#   - Python 3.10/3.11 with venv activated
+#
+# Usage:
+#   # Set credentials
+#   $env:OSU_CLIENT_ID = "your_id"
+#   $env:OSU_CLIENT_SECRET = "your_secret"
+#
+#   # Run all steps
+#   .\training\run_pipeline.ps1 -Step all
+#
+#   # Or individual steps
+#   .\training\run_pipeline.ps1 -Step download
+#   .\training\run_pipeline.ps1 -Step dataset
+#   .\training\run_pipeline.ps1 -Step train
+#
+# =============================================================================
+
+param(
+    [ValidateSet("download", "dataset", "train", "all")]
+    [string]$Step = "all"
+)
+
+$ErrorActionPreference = "Stop"
+$ProjectDir = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+Set-Location $ProjectDir
+
+$OszDir = ".\training\osz_2024_2025"
+$DatasetDir = ".\training\dataset_2024_2025"
+$YearStart = 2024
+$YearEnd = 2025
+
+Write-Host "============================================" -ForegroundColor Cyan
+Write-Host " Mapperatorinator 2024-2025 Training Pipeline" -ForegroundColor Cyan
+Write-Host "============================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host " Project:  $ProjectDir"
+Write-Host " OSZ Dir:  $OszDir"
+Write-Host " Dataset:  $DatasetDir"
+Write-Host ""
+
+function Step-Download {
+    Write-Host "=== Step 1: Download Beatmaps ===" -ForegroundColor Green
+    Write-Host ""
+
+    if (-not $env:OSU_CLIENT_ID -or -not $env:OSU_CLIENT_SECRET) {
+        Write-Host "ERROR: osu! OAuth credentials not set." -ForegroundColor Red
+        Write-Host '  $env:OSU_CLIENT_ID = "your_id"'
+        Write-Host '  $env:OSU_CLIENT_SECRET = "your_secret"'
+        Write-Host "  Get them at: https://osu.ppy.sh/home/account/edit"
+        exit 1
+    }
+
+    pip install requests tqdm 2>$null | Out-Null
+
+    python training/download_beatmaps.py `
+        --client-id $env:OSU_CLIENT_ID `
+        --client-secret $env:OSU_CLIENT_SECRET `
+        --output $OszDir `
+        --year-start $YearStart `
+        --year-end $YearEnd `
+        --status ranked loved
+
+    Write-Host ""
+    Write-Host "Download complete. .osz files in: $OszDir" -ForegroundColor Green
+}
+
+function Step-Dataset {
+    Write-Host "=== Step 2: Build Dataset ===" -ForegroundColor Green
+    Write-Host ""
+
+    pip install pandas pyarrow tqdm 2>$null | Out-Null
+
+    python training/build_dataset.py `
+        --input $OszDir `
+        --output $DatasetDir `
+        --delete-osz
+
+    # Get split values and update config
+    $splitInfo = python -c @"
+import pandas as pd
+from pathlib import Path
+df = pd.read_parquet(Path(r'$DatasetDir') / 'metadata.parquet')
+n = df.index.get_level_values(0).nunique()
+train_end = int(n * 0.9)
+print(f'{n},{train_end}')
+"@
+
+    $parts = $splitInfo.Split(',')
+    $total = $parts[0]
+    $trainEnd = $parts[1]
+
+    Write-Host ""
+    Write-Host "Dataset has $total beatmap sets." -ForegroundColor Yellow
+    Write-Host "  Train: 0 - $trainEnd"
+    Write-Host "  Test:  $trainEnd - $total"
+
+    # Update config
+    $configPath = "configs\train\lora_2024_2025.yaml"
+    $content = Get-Content $configPath -Raw
+    $content = $content -replace 'train_dataset_end: \d+', "train_dataset_end: $trainEnd"
+    $content = $content -replace 'test_dataset_start: \d+', "test_dataset_start: $trainEnd"
+    $content = $content -replace 'test_dataset_end: \d+', "test_dataset_end: $total"
+    Set-Content $configPath $content
+
+    Write-Host "Config updated: $configPath" -ForegroundColor Green
+}
+
+function Step-Train {
+    Write-Host "=== Step 3: LoRA Fine-Tune ===" -ForegroundColor Green
+    Write-Host ""
+
+    $datasetPath = (Resolve-Path $DatasetDir).Path
+
+    Write-Host "Training with dataset at: $datasetPath"
+    Write-Host "This will take a while depending on your GPU..." -ForegroundColor Yellow
+    Write-Host ""
+
+    python osuT5/train.py -cn lora_2024_2025 `
+        "data.train_dataset_path=`"$datasetPath`"" `
+        "data.test_dataset_path=`"$datasetPath`""
+
+    Write-Host ""
+    Write-Host "=== Training Complete ===" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "LoRA weights saved in checkpoint directory."
+    Write-Host "To use: set 'LoRA Path or ID' in the web UI to the checkpoint path."
+    Write-Host "CLI:    python inference.py lora_path=`"path/to/checkpoint`" year=2025"
+}
+
+switch ($Step) {
+    "download" { Step-Download }
+    "dataset"  { Step-Dataset }
+    "train"    { Step-Train }
+    "all" {
+        Step-Download
+        Step-Dataset
+        Step-Train
+    }
+}

--- a/training/run_pipeline.sh
+++ b/training/run_pipeline.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# =============================================================================
+# Full Training Pipeline for Mapperatorinator 2024-2025 Year Support
+# =============================================================================
+#
+# This script automates the entire process of adding year 2024-2025 support:
+#   1. Download ranked/loved beatmaps from 2024-2025
+#   2. Build a training dataset from the downloaded .osz files
+#   3. Run LoRA fine-tuning on the V31 model
+#
+# Prerequisites:
+#   - osu! OAuth credentials (get from https://osu.ppy.sh/home/account/edit)
+#   - NVIDIA GPU with CUDA (for training)
+#   - Docker + nvidia-container-toolkit (for containerized training)
+#   - OR: Local venv with all dependencies + flash-attn
+#
+# Usage:
+#   # Set your osu! OAuth credentials
+#   export OSU_CLIENT_ID="your_client_id"
+#   export OSU_CLIENT_SECRET="your_client_secret"
+#
+#   # Option A: Run everything
+#   ./training/run_pipeline.sh all
+#
+#   # Option B: Run individual steps
+#   ./training/run_pipeline.sh download    # Step 1: Download beatmaps
+#   ./training/run_pipeline.sh dataset     # Step 2: Build dataset
+#   ./training/run_pipeline.sh train       # Step 3: Run LoRA fine-tune
+#
+# =============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR"
+
+# Config
+OSZ_DIR="./training/osz_2024_2025"
+DATASET_DIR="./training/dataset_2024_2025"
+YEAR_START=2024
+YEAR_END=2025
+
+echo "============================================"
+echo " Mapperatorinator 2024-2025 Training Pipeline"
+echo "============================================"
+echo ""
+echo " Project: $PROJECT_DIR"
+echo " OSZ Dir: $OSZ_DIR"
+echo " Dataset: $DATASET_DIR"
+echo ""
+
+step_download() {
+    echo "=== Step 1: Download Beatmaps ==="
+    echo ""
+    
+    if [ -z "$OSU_CLIENT_ID" ] || [ -z "$OSU_CLIENT_SECRET" ]; then
+        echo "ERROR: osu! OAuth credentials not set."
+        echo "  export OSU_CLIENT_ID='your_id'"
+        echo "  export OSU_CLIENT_SECRET='your_secret'"
+        echo "  Get credentials at: https://osu.ppy.sh/home/account/edit"
+        exit 1
+    fi
+
+    pip install requests tqdm 2>/dev/null || true
+
+    python training/download_beatmaps.py \
+        --client-id "$OSU_CLIENT_ID" \
+        --client-secret "$OSU_CLIENT_SECRET" \
+        --output "$OSZ_DIR" \
+        --year-start $YEAR_START \
+        --year-end $YEAR_END \
+        --status ranked loved
+
+    echo ""
+    echo "Download complete. .osz files in: $OSZ_DIR"
+    echo ""
+}
+
+step_dataset() {
+    echo "=== Step 2: Build Dataset ==="
+    echo ""
+
+    pip install pandas pyarrow tqdm 2>/dev/null || true
+
+    python training/build_dataset.py \
+        --input "$OSZ_DIR" \
+        --output "$DATASET_DIR" \
+        --delete-osz
+
+    echo ""
+    echo "Dataset built in: $DATASET_DIR"
+    
+    # Calculate split values
+    N_SETS=$(python -c "
+import pandas as pd
+from pathlib import Path
+df = pd.read_parquet(Path('$DATASET_DIR') / 'metadata.parquet')
+n = df.index.get_level_values(0).nunique()
+print(n)
+")
+    TRAIN_END=$(python -c "print(int($N_SETS * 0.9))")
+    
+    echo ""
+    echo "Dataset has $N_SETS beatmap sets."
+    echo "  Train split: 0 - $TRAIN_END"
+    echo "  Test split:  $TRAIN_END - $N_SETS"
+    echo ""
+    echo "Updating lora_2024_2025.yaml with split values..."
+    
+    # Update the config file with actual dataset sizes
+    python -c "
+import re
+from pathlib import Path
+
+config_path = Path('configs/train/lora_2024_2025.yaml')
+text = config_path.read_text()
+
+text = re.sub(r'train_dataset_end: \d+', 'train_dataset_end: $TRAIN_END', text)
+text = re.sub(r'test_dataset_start: \d+', 'test_dataset_start: $TRAIN_END', text)
+text = re.sub(r'test_dataset_end: \d+', 'test_dataset_end: $N_SETS', text)
+
+config_path.write_text(text)
+print('Config updated.')
+"
+}
+
+step_train() {
+    echo "=== Step 3: LoRA Fine-Tune ==="
+    echo ""
+    echo "Training options:"
+    echo "  A) Docker (recommended for Linux/WSL)"
+    echo "  B) Local venv (if you have flash-attn installed)"
+    echo ""
+    
+    # Check if running in Docker
+    if [ -f /.dockerenv ]; then
+        echo "Running inside Docker container."
+        DATASET_PATH="/workspace/datasets/MMRS_2024_2025"
+        
+        # Copy dataset to expected location if needed
+        if [ ! -d "$DATASET_PATH" ] && [ -d "$DATASET_DIR" ]; then
+            echo "Copying dataset to $DATASET_PATH..."
+            cp -r "$DATASET_DIR" "$DATASET_PATH"
+        fi
+        
+        python osuT5/train.py -cn lora_2024_2025 \
+            data.train_dataset_path="$DATASET_PATH" \
+            data.test_dataset_path="$DATASET_PATH"
+    else
+        echo "Running locally (outside Docker)."
+        echo ""
+        echo "If you have flash-attn installed, training will run locally."
+        echo "Otherwise, use Docker:"
+        echo "  docker compose up -d --force-recreate"
+        echo "  docker attach mapperatorinator_space"
+        echo "  cd Mapperatorinator"
+        echo "  ./training/run_pipeline.sh train"
+        echo ""
+        
+        DATASET_PATH="$(realpath "$DATASET_DIR")"
+        
+        python osuT5/train.py -cn lora_2024_2025 \
+            data.train_dataset_path="$DATASET_PATH" \
+            data.test_dataset_path="$DATASET_PATH"
+    fi
+    
+    echo ""
+    echo "=== Training Complete ==="
+    echo ""
+    echo "Your LoRA weights are saved in the checkpoint directory."
+    echo "To use them during inference, set lora_path to the checkpoint path."
+    echo ""
+    echo "In the web UI: set the 'LoRA Path or ID' field to your checkpoint path."
+    echo "In CLI: python inference.py lora_path=\"path/to/checkpoint\" year=2025"
+}
+
+# Main
+case "${1:-all}" in
+    download)
+        step_download
+        ;;
+    dataset)
+        step_dataset
+        ;;
+    train)
+        step_train
+        ;;
+    all)
+        step_download
+        step_dataset
+        step_train
+        ;;
+    *)
+        echo "Usage: $0 {download|dataset|train|all}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Adds a complete training pipeline for LoRA fine-tuning on custom year ranges of beatmap data. This enables creating model variants trained on newer beatmaps.

## New Files
- **`training/download_beatmaps.py`**: Downloads ranked beatmaps from a configurable year range via osu! API
- **`training/build_dataset.py`**: Converts downloaded beatmaps into MMRS training format
- **`training/run_pipeline.sh`** / **`run_pipeline.ps1`**: End-to-end scripts (download → build → train) for Linux/Windows
- **`training/README.md`**: Documentation for the pipeline
- **`configs/train/lora_2024_2026.yaml`**: Example LoRA training config for 2024-2026 data

## Features
- Downloads ranked beatmaps filtered by year range and optionally by known mapper IDs
- Builds MMRS-format dataset with proper metadata columns (StarRating, DifficultyRating, etc.)
- LoRA config tuned for 12GB VRAM GPUs (batch_size=32 with grad_acc=32)
- Supports auto-resume via checkpoint detection
- Cross-platform (bash + PowerShell)