### PR TITLE
Fix webview window launch

### DIFF
--- a/mai_mod_ui.py
+++ b/mai_mod_ui.py
@@ -8,6 +8,7 @@ import sys
 import threading
 import time
 import datetime
+import traceback
 from typing import Callable, Any, Tuple, Dict
 
 import webview
@@ -519,6 +520,39 @@ def find_available_port(start_port=5000, max_tries=100):
     raise IOError("Could not find an available port.")
 
 
+def launch_browser_fallback(flask_url, flask_thread):
+    """Keep the server alive when an embedded window cannot be created."""
+    print(f"Running without an embedded window. Open {flask_url} in your browser.")
+    print("Press Ctrl+C to stop the server.")
+
+    try:
+        while flask_thread.is_alive():
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("\nStopping server...")
+
+
+def launch_webview_window(window_title, flask_url, window_width, window_height, api):
+    """Create the embedded pywebview window when a GUI backend is available."""
+    print(f"Creating pywebview window loading URL: {flask_url}")
+    try:
+        webview.create_window(
+            window_title,
+            url=flask_url,
+            width=window_width,
+            height=window_height,
+            resizable=True,
+            js_api=api,
+        )
+        webview.start(debug=False)
+        print("Pywebview window closed. Exiting application.")
+        return True
+    except Exception as e:
+        print(f"pywebview could not start an embedded window: {e}")
+        print(traceback.format_exc())
+        return False
+
+
 # --- Main Execution ---
 if __name__ == '__main__':
     # Find an available port for Flask
@@ -551,23 +585,8 @@ if __name__ == '__main__':
     window_title = 'MaiMod'
     flask_url = f'http://127.0.0.1:{flask_port}/'
 
-    print(f"Creating pywebview window loading URL: {flask_url}")
-
     # Instantiate the API class (doesn't need window object anymore)
     api = Api()
 
-    # Pass api instance directly to create_window via js_api
-    window = webview.create_window(
-        window_title,
-        url=flask_url,
-        width=window_width,  # Use calculated width
-        height=window_height,  # Use calculated height
-        resizable=True,
-        js_api=api  # Expose Python API class here
-    )
-
-    # Start the pywebview event loop (no args needed here now)
-    webview.start(debug=False)
-
-    print("Pywebview window closed. Exiting application.")
-    # Flask thread will exit automatically as it's a daemon
+    if not launch_webview_window(window_title, flask_url, window_width, window_height, api):
+        launch_browser_fallback(flask_url, flask_thread)

--- a/web-ui.py
+++ b/web-ui.py
@@ -702,6 +702,39 @@ def find_available_port(start_port=5000, max_tries=100):
     raise IOError("Could not find an available port.")
 
 
+def launch_browser_fallback(flask_url, flask_thread):
+    """Keep the server alive when an embedded window cannot be created."""
+    print(f"Running without an embedded window. Open {flask_url} in your browser.")
+    print("Press Ctrl+C to stop the server.")
+
+    try:
+        while flask_thread.is_alive():
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("\nStopping server...")
+
+
+def launch_webview_window(window_title, flask_url, window_width, window_height, api):
+    """Create the embedded pywebview window when a GUI backend is available."""
+    print(f"Creating pywebview window loading URL: {flask_url}")
+    try:
+        webview.create_window(
+            window_title,
+            url=flask_url,
+            width=window_width,
+            height=window_height,
+            resizable=True,
+            js_api=api,
+        )
+        webview.start()
+        print("Pywebview window closed. Exiting application.")
+        return True
+    except Exception as e:
+        print(f"pywebview could not start an embedded window: {e}")
+        print(traceback.format_exc())
+        return False
+
+
 # --- Main Execution ---
 if __name__ == '__main__':
     # Find an available port for Flask
@@ -734,23 +767,8 @@ if __name__ == '__main__':
     window_title = 'Mapperatorinator'
     flask_url = f'http://127.0.0.1:{flask_port}/'
 
-    print(f"Creating pywebview window loading URL: {flask_url}")
-
     # Instantiate the API class (doesn't need window object anymore)
     api = Api()
 
-    # Pass api instance directly to create_window via js_api
-    window = webview.create_window(
-        window_title,
-        url=flask_url,
-        width=window_width,  # Use calculated width
-        height=window_height,  # Use calculated height
-        resizable=True,
-        js_api=api  # Expose Python API class here
-    )
-
-    # Start the pywebview event loop (no args needed here now)
-    webview.start()
-
-    print("Pywebview window closed. Exiting application.")
-    # Flask thread will exit automatically as it's a daemon
+    if not launch_webview_window(window_title, flask_url, window_width, window_height, api):
+        launch_browser_fallback(flask_url, flask_thread)


### PR DESCRIPTION
## Summary

This change makes both desktop UI launchers resilient when pywebview fails to start the native window on macOS.

Instead of exiting after the Cocoa backend crashes during `webview.start()`, the app now:

- keeps the Flask server running
- logs the full traceback for debugging
- prints the local browser URL
- lets the user continue using the UI in a normal browser

## Issue

### macOS: Cocoa backend crashes when NSScreen.mainScreen() is None

### Environment
- macOS 26.4 (25E246)
- Python 3.10.20
- pywebview 6.1
- PyQtWebEngine 5.15.7

### Traceback
```
Traceback (most recent call last):
  File "/Users/l/projects/Mapperatorinator/web-ui.py", line 753, in <module>
    webview.start()
  File "/Users/l/projects/Mapperatorinator/.venv/lib/python3.10/site-packages/webview/__init__.py", line 304, in start
    guilib.create_window(windows[0])
  File "/Users/l/projects/Mapperatorinator/.venv/lib/python3.10/site-packages/webview/platforms/cocoa.py", line 1399, in create_window
    create()
  File "/Users/l/projects/Mapperatorinator/.venv/lib/python3.10/site-packages/webview/platforms/cocoa.py", line 1394, in create
    browser = BrowserView(window)
  File "/Users/l/projects/Mapperatorinator/.venv/lib/python3.10/site-packages/webview/platforms/cocoa.py", line 562, in __init__
    self.screen = AppKit.NSScreen.mainScreen().frame()
AttributeError: 'NoneType' object has no attribute 'frame'
```

## What changed

In `web-ui.py` and `mai_mod_ui.py`:

- wrapped native window startup in `launch_webview_window(...)`
- added `launch_browser_fallback(...)` to keep the server alive when embedded window creation fails
- added traceback logging so pywebview startup failures are still diagnosable
- preserved existing behavior when pywebview starts successfully